### PR TITLE
linux-firmware: Add jetson-tx2 as a supported device

### DIFF
--- a/contracts/sw.image/linux-firmware/contract.json
+++ b/contracts/sw.image/linux-firmware/contract.json
@@ -8,7 +8,8 @@
       "anyOf": [
         { "type": "hw.device-type", "slug": "ccimx8x-sbc-pro" },
         { "type": "hw.device-type", "slug": "raspberrypi4-64" },
-        { "type": "hw.device-type", "slug": "genericx86-64-ext" }
+        { "type": "hw.device-type", "slug": "genericx86-64-ext" },
+        { "type": "hw.device-type", "slug": "jetson-tx2" }
       ],
       "allOf": [
         { "type": "sw.package", "slug": "linux-firmware" }

--- a/repo.yml
+++ b/repo.yml
@@ -1,0 +1,1 @@
+type: 'generic'


### PR DESCRIPTION
Add the jetson-tx2 to the list of supported devices.

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>